### PR TITLE
Fix `AttributeError: type object 'Dropdown' has no attribute 'update'`

### DIFF
--- a/CoppyLora_webUI.py
+++ b/CoppyLora_webUI.py
@@ -89,7 +89,7 @@ def get_base_model_options():
 
 # base_model を選択肢として更新するための関数
 def update_base_model_options():
-    return gr.Dropdown.update(choices=get_base_model_options())
+    return gr.Dropdown(choices=get_base_model_options())
 
 def find_free_port(start_port=7860):
     """指定したポートから開始して空いているポートを見つけて返す関数"""

--- a/CoppyLora_webUI_colab.py
+++ b/CoppyLora_webUI_colab.py
@@ -88,7 +88,7 @@ def get_base_model_options():
 
 # base_model を選択肢として更新するための関数
 def update_base_model_options():
-    return gr.Dropdown.update(choices=get_base_model_options())
+    return gr.Dropdown(choices=get_base_model_options())
 
 def find_free_port(start_port=7860):
     """指定したポートから開始して空いているポートを見つけて返す関数"""


### PR DESCRIPTION
Thank you for sharing useful tool.
When I tried to run this app from this repo, I got `AttributeError: type object 'Dropdown' has no attribute 'update'` when I click List Update button on DetailTrain tab.

https://github.com/user-attachments/assets/a02f43af-2975-4904-b06d-964b6b45b256

I'm not very familiar with Gradio though, it seems `update` is no longer available since Gradio 4.0.

https://github.com/gradio-app/gradio/issues/6339

> Removes the deprecated .update() method from component classes. Instead, you can now just return an instance of a component from your function. I.e. return gr.Textbox(lines=4) instead of gr.Textbox.update(lines=4)

This line implies this app should run with Gradio 4.44.1, so I guess you have this patch on your end to make the dropdown work.

https://github.com/tori29umai0123/CoppyLora_webUI/blob/d819d01b02ed7bda6e4fea0632e367929e650927/CoppyLora_webUI_install.ps1#L22

I confirmed this patch fixes the issue.

https://github.com/user-attachments/assets/0d3b291a-13cf-4c76-86dc-1815681419ab

---

便利なツールの共有ありがとうございます。
このリポジトリからセットアップを試したところ、 List Update ボタンを押すと `AttributeError: type object 'Dropdown' has no attribute 'update'` エラーになって更新ができませんでした。

私は Gradio に詳しいわけではないのですが (もっというと Python やそれにまつわるエコシステムにも詳しくはないのですが)、どうやら `update` は 4.0 で廃止になったようです。

install.ps1 を見る限り、おそらくこのアプリは Gradio 4 系で動作することを想定しているのだと思うので、もしかするととりにくさんの手元ではこのようなパッチがすでに当たっているかと思いますが、せっかく OSS として公開されているのですからパッチを投げてみた次第です。